### PR TITLE
Send mailing id on unsubscribe

### DIFF
--- a/source/javascripts/sumofus/backbone/unsubscribe_form.js
+++ b/source/javascripts/sumofus/backbone/unsubscribe_form.js
@@ -9,8 +9,17 @@ const UnsubscribeForm = Backbone.View.extend({
   },
 
   initialize() {
+    this.setMailingId();
     this.setSource();
     this.setLanguage();
+  },
+
+  setMailingId() {
+    let akid = this.getURLParameter('akid');
+    if(typeof(akid) === 'string') {
+      let mailingId = akid.split('.')[0];
+      this.$('input[name="mailing_id"]').val(mailingId);
+    }
   },
 
   setSource() {

--- a/source/localizable/_unsubscribe.slim
+++ b/source/localizable/_unsubscribe.slim
@@ -9,6 +9,8 @@ form.form.form--big.unsubscribe-form name="act" method="POST" action="//act.sumo
   input type="hidden" name="form_name" value="act"
   input type="hidden" name="url" value="//sumofus.org#{translate_link("/unsubscribe", I18n.locale)}"
 
+  input type="hidden" name="mailing_id" value=""
+
   .unsubscribe-form__group.form__group.unsubscribe-form__failure.hidden-irrelevant
     = t('pages.unsubscribe.generic_error')
   .unsubscribe-form__group.form__group


### PR DESCRIPTION
I'm manually taking the `mailing_id` from the akid if the param is present in the URL, and I'm sending it when making the request to AK to unsubscribe the user. 

I don't t think it's a big deal, but something be aware of is that I'm not validating the akid, so it might be easily tampered with. 