### PR TITLE
Updated copyright to 2018 & anonymised GA

### DIFF
--- a/source/localizable/_footer.slim
+++ b/source/localizable/_footer.slim
@@ -31,7 +31,7 @@
         a.fa.big-footer__social-icon.big-footer__social-icon--github href="//github.com/SumOfUs/"
         a.fa.big-footer__social-icon.big-footer__social-icon--youtube href="https://www.youtube.com/user/SumOfUsTube"
     .big-footer__license
-      | &copy; 2017 SumOfUs, #{t('branding.license')}
+      | &copy; 2018 SumOfUs, #{t('branding.license')}
 
 javascript:
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -39,4 +39,5 @@ javascript:
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-26370633-1', 'auto');
+  ga('set','anonymizeIp',true);
   ga('send', 'pageview');


### PR DESCRIPTION
Our page footers say (c) 2017 SumOfUs. Now they'll say (c) 2018 SumOfUs.
I've also added this line to our Google Analytics javascript, which is what's recommended for GDPR compliance:
ga('set','anonymizeIp',true);

For more info about the anonymiseIp setting, please see: https://support.google.com/analytics/answer/2763052?hl=en