### PR TITLE
Include board page css

### DIFF
--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -7,7 +7,7 @@
 @import "sumofus/components/logo";
 @import "sumofus/components/campaign-tile";
 @import "sumofus/components/press-tile";
-// @import "sumofus/components/staff";
+@import "sumofus/components/staff";
 @import "sumofus/components/modal";
 @import "sumofus/pages/funding";
 @import "sumofus/pages/privacy";


### PR DESCRIPTION
When staff page was removed the css corresponding to it was also removed which has collapsed the board page which uses the same set of styles