### PR TITLE
Revert CI settings back to what they were

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
       - run: echo $production
 
       # Restore bundle cache
-#      - type: cache-restore
-#        key: sou-homepage
-#
+      - type: cache-restore
+        key: sou-homepage
+
       # Install dependencies and build
       - run: bundle install --path vendor/bundle
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/sou-homepage-deploy
   docker:
-    - image: souadmin/homepage-deploy:0.6
+    - image: souadmin/homepage-deploy:0.0.2
 
 version: 2
 jobs:
@@ -10,18 +10,20 @@ jobs:
     steps:
       - checkout
 
+      - run: echo $production
+
       # Restore bundle cache
       - type: cache-restore
-        key: sou-homepage-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+        key: sou-homepage
 
       # Install dependencies and build
       - run: bundle install --path vendor/bundle
       - run: yarn install
-      - run: LANG=C.UTF-8 bundle exec middleman build
+      - run: bundle exec middleman build
 
       # Store bundle cache
       - type: cache-save
-        key: sou-homepage-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+        key: sou-homepage
         paths:
           - vendor/bundle
           - node_modules
@@ -35,7 +37,7 @@ jobs:
       - deploy:
           name: Deploy
           command: |
-            if [ "${CIRCLE_BRANCH}" == "development" ]; then
+            if [ "${CIRCLE_BRANCH}" == "revert-ci" ]; then
               aws s3 sync build s3://staging.homepage.sumofus.org --acl public-read --cache-control "public, max-age=0" --delete --region us-west-2
             fi
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
       - run: echo $production
 
       # Restore bundle cache
-      - type: cache-restore
-        key: sou-homepage
-
+#      - type: cache-restore
+#        key: sou-homepage
+#
       # Install dependencies and build
       - run: bundle install --path vendor/bundle
       - run: yarn install

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,10 +1,7 @@
-FROM ruby:2.6.2
-RUN apt-get update && apt-get install -y \
-  curl \
-  build-essential \
-  awscli \
-  libpq-dev &&\
-  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install -y nodejs yarn
+FROM circleci/ruby:2.4.1-node
+
+RUN sudo apt-get update && sudo apt-get install -y awscli
+RUN sudo apt-get install apt-transport-https
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN sudo apt-get update && sudo apt-get install yarn

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.6.2"
+ruby "2.4.1"
 
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.17.2
+   1.17.1


### PR DESCRIPTION
Note - cache has been disabled. Because of how this is set up, it sets cache up as root and then fails to untar it - we need to fix this come new year.