### PR TITLE
Hide Press Hits For Arabic Version

### DIFF
--- a/source/localizable/_nav.slim
+++ b/source/localizable/_nav.slim
@@ -41,16 +41,16 @@
           option[value="es"] ESPAÑOL
           option[value="pt"] PORTUGUÊS
           option[value="nl"] NEDERLANDS
-          option[value="ar"] ARABIC
+          option[value="ar"] العربيّة
       .mobile-lang-select
-        select.language-select.mobile
+        select.language-select.mobile class=("#{I18n.locale()}")
           option[value="en" selected="selected"] ENG
           option[value="de"] DEU
           option[value="fr"] FRA
           option[value="es"] ESP
           option[value="pt"] POR
           option[value="nl"] NLD
-          option[value="ar"] ARA
+          option[value="ar"] العربيّة
   .mobile-nav-options
     a.mobile__nav-item href=translate_link('/disinfo', I18n.locale())
       div disinfo

--- a/source/localizable/_nav.slim
+++ b/source/localizable/_nav.slim
@@ -23,7 +23,7 @@
           div = t('homepage.nav.press')
         a.header__nav-item href=translate_link('/campaigns', I18n.locale())
           div = t('homepage.nav.campaigns')
-        a.header__nav-item href=translate_link('/disinfo', I18n.locale())
+        a.header__nav-item href=translate_link('/disinfo', I18n.locale()) class=("#{I18n.locale()}" == 'ar' ? 'hidden-irrelevant' : '')
           div = t('homepage.nav.disinfo')
         a.header__nav-item href=t('homepage.nav.covidLink')
           div = t('homepage.nav.covid')

--- a/source/localizable/index.html.slim
+++ b/source/localizable/index.html.slim
@@ -148,4 +148,7 @@ javascript:
         $('#non-gdpr-join-button').removeClass('hidden-irrelevant');
       }
     });
+    if ("#{I18n.locale()}" === 'ar') {
+      $('.full-screen-block--expandable.press-block').addClass('hidden-irrelevant');
+    }
   });

--- a/source/stylesheets/_pages.scss
+++ b/source/stylesheets/_pages.scss
@@ -361,6 +361,9 @@
             display: block;
             .language-select {
               width: 62px;
+              &.ar {
+                font-size: 12px;
+              }
             }
           }
         }

--- a/source/stylesheets/sumofus/pages/privacy.scss
+++ b/source/stylesheets/sumofus/pages/privacy.scss
@@ -4,6 +4,7 @@ body.privacy {
   }
   .link_style{
     text-decoration: underline;
+    text-underline-position: under;
     color: $uni-blue;
     cursor: pointer;
     padding-bottom: 16px;


### PR DESCRIPTION
### Overview
* Press Hits are not needed in the Arabic version, as confirmed by Rewan.
* Set underline position to under so we have more padding between the text and the underline.
* Hide disinfo nav item if the locale is AR 

### Tickets
https://app.asana.com/0/1119304937718815/1201707345776732/f
https://app.asana.com/0/1119304937718815/1201800818096122/f
https://app.asana.com/0/1119304937718815/1201800832248804/f

### Screenshot
![Screen Shot 2022-02-10 at 15 46 19](https://user-images.githubusercontent.com/15176901/153509541-6b67b796-98da-447e-9b30-31f33629a83b.png)

![Screen Shot 2022-02-10 at 17 25 37](https://user-images.githubusercontent.com/15176901/153519486-df7a35eb-99a8-4548-a3b4-402c5e7530ab.png)

![Screen Shot 2022-02-10 at 17 31 45](https://user-images.githubusercontent.com/15176901/153520041-6bfd2700-a152-4a4b-b985-d49730ce045e.png)

