### PR TITLE
Wrong language is selected on the media page

### DIFF
--- a/source/localizable/_nav.slim
+++ b/source/localizable/_nav.slim
@@ -72,11 +72,12 @@
 javascript:
   $(document).ready(function(){
     // Regex to find the current lang of the page
-   const langSupported = ['de', 'fr', 'es', 'pt', 'nl', 'ar'];
-   const current_path = window.location.pathname.includes('media/')
+   const regex = /\/(fr|de|es|pt|nl|ar)\/+/;
+   const mediaPathRegex = /(media\/.+)/;
+   const current_path = window.location.pathname.match(mediaPathRegex)
                         ? "/media"
                         : window.location.pathname;
-    const current_lang = langSupported.includes(current_path.split('/')[1]) ? current_path.split('/')[1] : 'en';
+    const current_lang = current_path.match(regex) ? current_path.match(regex)[1] : 'en';
 
     const langComponents = [...$('.language-select')];
     langComponents.forEach(function(select) {select.value = current_lang});


### PR DESCRIPTION
Locally this works, but on staging and production, the URL looks like this: https://homepage.staging.sumofus.org/ar/media/.
The last `/` is causing the issue, which is happening for all languages, not just AR.