### PR TITLE
Remove link to staff on FAQ page

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -98,7 +98,7 @@ de:
       financial: Fragen zur Finanzierung
       privacy: Privatsphäre & Datenschutz
       campaigns: Kampagnen
-      staff: Unser Team
+      staff: Team
       programs: Programm
       admin: Management und Allgemeines
       fundraising: Fundraising and Development

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -99,7 +99,7 @@ en:
       financial: Financial Information
       privacy: Privacy & Data Protection
       campaigns: Campaigns
-      staff: Our Staff
+      staff: Staff
       programs: Programs
       admin: Admin
       fundraising: Fundraising and Development

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -98,7 +98,7 @@ es:
       financial: Información Financiera
       privacy: Privacidad y Protección de Datos
       campaigns: Campañas
-      staff: Nuestro equipo
+      staff: Equipo
       programs: Programas
       admin: Admin
       fundraising: Recaudación de fondos y desarrollo

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -98,7 +98,7 @@ fr:
       financial: Informations sur nos finances
       privacy: Confidentialité & protection des données
       campaigns: Campagnes
-      staff: Nos équipes
+      staff: Équipe
       programs: Campagnes
       admin: Administration
       fundraising: Récolte de fonds

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -98,7 +98,7 @@ nl:
       financial: Financiële informatie 
       privacy: Privacy- & Gegevensbescherming
       campaigns: Campagnes
-      staff: Onze medewerkers
+      staff: Medewerkers
       programs: Programma’s
       admin: Admin
       fundraising: Fondsenwerving en Ontwikkeling

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -98,7 +98,7 @@ pt:
       financial: Informações Financeiras
       privacy: Privacidade & Proteção de Dados
       campaigns: Campanhas
-      staff: Nossa Equipe
+      staff: Equipe
       programs: Programas
       admin: Admin
       fundraising: Desenvolvimento & Arrecadação de Fundos


### PR DESCRIPTION
## Overview

The section header is shown as OUR STAFF but the section contains only one question related to job openings. I have updated the title to be only STAFF because that is more meaningful. 
Have updated the context for all locales

## Asana Ticket
[Link to staff is not working](https://app.asana.com/0/1119304937718815/1202057039119256/f)

## Screenshots

Existing:
<img width="1245" alt="Screenshot 2022-05-02 at 5 44 00 PM" src="https://user-images.githubusercontent.com/49471498/166231790-dd587548-4f56-47c4-a9f7-55f045eab181.png">

New/Updated:
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/49471498/166231862-9a66e5af-6a74-42ce-baea-7b3d6a33aa94.png">
