### PR TITLE
Start a petition link on the navigation bar

### DIFF
--- a/source/localizable/_nav.slim
+++ b/source/localizable/_nav.slim
@@ -31,6 +31,8 @@
           div = t('homepage.nav.about')
         a.header__nav-item href=translate_link('/storyofus', I18n.locale()) class=("#{I18n.locale()}" == 'ar' ? 'hidden-irrelevant' : '')
           div = t('sou.storyofus')
+        a.header__nav-item.start_petition_link target='_blank' href='https://petitions.sumofus.org/petition/start?source=header' class=("#{I18n.locale()}" == 'en' ? '' : 'hidden-irrelevant') 
+          div = 'Start a Petition' 
       .header-options
         a.header__nav-item.donate-button href=t('footer.donate_link')
           div = t('homepage.nav.donate')
@@ -52,6 +54,8 @@
           option[value="nl"] NLD
           option[value="ar"] العربيّة
   .mobile-nav-options
+    a.mobile__nav-item.start_petition_link target='_blank' id='petitions' href='https://petitions.sumofus.org/petition/start?source=header' class=("#{I18n.locale()}" == 'en' ? '' : 'hidden-irrelevant') 
+      div = 'Start a Petition'
     a.mobile__nav-item href=translate_link('/disinfo', I18n.locale())
       div disinfo
     a.mobile__nav-item href=t('homepage.nav.covidLink')
@@ -111,7 +115,10 @@ javascript:
         $('.mobile-nav-options').css({'transform': 'translateY(0px)', 'visibility': 'visible'});
       }
     });
-     $(document).on('scroll', function() {
-       window.innerWidth < 730 && window.scrollY && $('#nav-icon').hasClass('open') ? $('#nav-icon').click() : null;
-     })
+    $(document).on('scroll', function() {
+      window.innerWidth < 730 && window.scrollY && $('#nav-icon').hasClass('open') ? $('#nav-icon').click() : null;
+    })
+    $('.start_petition_link').on('click', function() {
+      window.ga("send", "event", "petitions", "start_clicked", "header");
+    })
   });

--- a/source/stylesheets/_pages.scss
+++ b/source/stylesheets/_pages.scss
@@ -1025,20 +1025,19 @@
   transform: translateY(-260px);
   position: relative;
   z-index: 0;
-  height: 180px;
+  height: 300px;
   width: 100%;
   background: $white;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
   align-items: baseline;
-  padding: 5px 0;
   transition: transform 0.5s ease-in-out;
   -webkit-transition: transform 0.5s ease-in-out;
   a {
     font-size: 16px;
     color: $new-navy;
-    padding: 0 20px;
+    padding: 10px 20px;
   }
 }
 


### PR DESCRIPTION
We wanted to allow users to find the "Start a petition" page for lifting the exposure to the CS experiment. 

AC:
- [ ] Show "Start a petition" on the navigation bar

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/49471498/171404904-e2a18b70-0da1-4c4c-afb3-ecc7f9dc985d.png">
<img width="417" alt="image" src="https://user-images.githubusercontent.com/49471498/171405045-eb7eba62-4084-4485-ba58-6ba69d5a207d.png">


- [ ] Clicking on the link should lead to "https://petitions.sumofus.org/petition/start?source=header"


- [ ] Should be able to track users/count who clicks on the link 
Available under google analytics [tracking id - UA-26370633-1](https://analytics.google.com/analytics/web/?authuser=2#/report-home/a26370633w51027782p51695109/%3F_.gSectionId=ecommerce)
<img width="1588" alt="image" src="https://user-images.githubusercontent.com/49471498/171404377-c069c423-28c7-4789-b895-b5c99a66a14e.png">


- [ ] Shown only on EN (as we are currently experimenting only with the English language) 
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/49471498/171405268-493ca9db-2d22-4e11-9864-a52cbe7557a5.png">
