### PR TITLE
Using Ekō logo

### DIFF
--- a/source/404.html
+++ b/source/404.html
@@ -138,7 +138,7 @@
   <!-- This file lives in public/404.html -->
   <div>
     <div class="brand-logo-banner">
-      <img src="./images/sumofus-logo-horizontal.svg" class="sou-logo">
+      <img src="https://sumofus.imgix.net/unique/Eko_Logo_Black.svg" class="sou-logo">
     </div>
     <div class="section">
       <div class="background-image-404">

--- a/source/localizable/_modal.slim
+++ b/source/localizable/_modal.slim
@@ -2,7 +2,7 @@
   .modal-content
     #modal-header
       span.close x
-      = image_tag image_path('sumofus-logo-horizontal.svg'), class: "logo-desktop"
+      = image_tag image_path('https://sumofus.imgix.net/unique/Eko_Logo_Black.svg'), class: "logo-desktop"
     #modal-inner
       div.content-title = t('modal.short_message')
       div.content-message

--- a/source/localizable/_nav.slim
+++ b/source/localizable/_nav.slim
@@ -14,10 +14,10 @@
           span
         .header-image
           = link_to translate_link('/', I18n.locale()) do
-            = image_tag image_path('sumofus-logo.svg'), class: 'dark-logo'
-            = image_tag image_path('sumofus-white-logo.svg'), class: 'white-logo'
-            = image_tag image_path('sumofus-logo-horizontal.svg'), class: 'horizontal-logo'
-            = image_tag image_path('sumofus-white-logo-horizontal.svg'), class: 'white-horizontal-logo'
+            = image_tag image_path('https://sumofus.imgix.net/unique/Eko_Logo_Black.svg'), class: 'dark-logo'
+            = image_tag image_path('https://sumofus.imgix.net/unique/Eko_Logo_White.svg'), class: 'white-logo'
+            = image_tag image_path('https://sumofus.imgix.net/unique/Eko_Logo_Black.svg'), class: 'horizontal-logo'
+            = image_tag image_path('https://sumofus.imgix.net/unique/Eko_Logo_White.svg'), class: 'white-horizontal-logo'
       .header-nav-items
         a.header__nav-item href=translate_link('/media', I18n.locale())
           div = t('homepage.nav.press')

--- a/source/stylesheets/_pages.scss
+++ b/source/stylesheets/_pages.scss
@@ -433,6 +433,10 @@
   &--landing-page.headroom--top {
     .white-logo {
       display: block;
+      padding: 0;
+      margin: 0 auto 16px 0;
+      max-height: 100%;
+      max-width: 100%;
       @media (max-width: $mobile-nav-width) {
         display: none;
       }
@@ -459,8 +463,10 @@
       display: none;
       @media (max-width: $mobile-nav-width) {
         display: block;
-        height: 17px;
-        width: 88px;
+        padding: 0;
+        margin: 0 auto 16px 0;
+        max-height: 80%;
+        max-width: 40%;
       }
     }
   }
@@ -507,8 +513,10 @@
     }
     .horizontal-logo {
       display: block;
-      width: 88px;
-      height: 17px;
+      padding: 0;
+      margin: 0 auto 16px 0;
+      max-height: 80%;
+      max-width: 40%;
     }
   }
 
@@ -545,8 +553,12 @@
     }
     .horizontal-logo {
       display: block;
+      padding: 0;
+      margin: 0 auto 16px 0;
+      max-height: 75%;
+      max-width: 75%;
       @media (max-width: $mobile-nav-width) {
-        height: 17px;
+        height: 24px;
         width: 88px;
       }
     }
@@ -592,8 +604,9 @@
       .logo-desktop {
         height: 86px;
         width: 96px;
-        background-image: url('../images/sumofus-white-logo.svg');
+        background-image: url('https://sumofus.imgix.net/unique/Eko_Logo_White.svg');
         background-size: contain;
+        background-repeat: no-repeat;
         @media (max-width: 730px) {
           height: 56px;
           width: 66px;
@@ -945,6 +958,7 @@
   display: none;
   width: 24px;
   margin-right: 20px;
+  margin-top: 10px;
   position: relative;
   z-index: 999;
   -webkit-transform: rotate(0deg);


### PR DESCRIPTION
### Overview
* Replace SumOfUs logo with the Ekō logo
    * Used the white and black versions, which look good with the current layout and color palette.  

### Screenshots
![Screen Shot 2023-01-09 at 17 08 53](https://user-images.githubusercontent.com/15176901/211427779-560b3001-1ff2-4302-8742-217ef8ec57b5.png)

![Screen Shot 2023-01-09 at 17 09 08](https://user-images.githubusercontent.com/15176901/211427790-6a13b22e-a01c-4743-98cd-a6660fee34ab.png)

![Screen Shot 2023-01-09 at 17 11 33](https://user-images.githubusercontent.com/15176901/211427796-1d067746-0174-4c5e-aa9d-5ddd57c96ad8.png)

![Screen Shot 2023-01-09 at 17 11 48](https://user-images.githubusercontent.com/15176901/211427800-b6f4e99f-6a51-445c-9302-ee4ce39356df.png)

![Screen Shot 2023-01-09 at 17 12 01](https://user-images.githubusercontent.com/15176901/211427803-c65616ab-0754-4bb3-ad64-b57578db9e43.png)

![Screen Shot 2023-01-09 at 17 12 11](https://user-images.githubusercontent.com/15176901/211427804-00831b10-a15c-4d0c-9fa7-4846718d4cb2.png)

![Screen Shot 2023-01-09 at 17 12 46](https://user-images.githubusercontent.com/15176901/211427808-cb890683-92e7-4667-b27e-62262f4ab1e2.png)

![Screen Shot 2023-01-09 at 17 12 58](https://user-images.githubusercontent.com/15176901/211427809-039d08d1-a97b-4140-ae5b-57694bba5e7b.png)

![Screen Shot 2023-01-09 at 17 13 49](https://user-images.githubusercontent.com/15176901/211427813-8c17b14d-4cdf-4db7-95fe-89d96d289701.png)

![Screen Shot 2023-01-09 at 17 14 57](https://user-images.githubusercontent.com/15176901/211427814-71086fb4-25c2-46de-b560-2d4ba945cca8.png)
