### PR TITLE
Homepage SOU image replace

### DIFF
--- a/source/stylesheets/_homepage.scss
+++ b/source/stylesheets/_homepage.scss
@@ -172,14 +172,14 @@ h1 {
     right: 0;
     z-index: 9;
     background-color: $new-navy;
-    background-image: url(image_path('media-attention.jpg'));
+    background-image: url(image_path('https://sumofus.imgix.net/unique/Eko_homepage_header.png'));
     background-size: cover;
     width: 100%;
     height: 100%;
     background-repeat: no-repeat;
     background-position: center;
     background: linear-gradient(0deg, rgba($black, 0.3), rgba($new-navy, 0.8)),
-      url(image_path('media-attention.jpg')) center no-repeat;
+      url(image_path('https://sumofus.imgix.net/unique/Eko_homepage_header.png')) center no-repeat;
     background-size: cover;
     &--shells {
       background-image: url(image_path('shells.jpg'));


### PR DESCRIPTION
### Overview
Replace the homepage image that has SumOfUs branding with an Ekō image.



![Screen Shot 2023-01-18 at 15 11 48](https://user-images.githubusercontent.com/15176901/213295723-0bac9265-3d2a-4641-a33a-9c2c36e4c3d6.png)


![Screen Shot 2023-01-18 at 15 12 04](https://user-images.githubusercontent.com/15176901/213295741-47f6df6d-9d69-4320-b61a-f73a34d99d23.png)
