### PR TITLE
Fixing wrong donate URLs

### DIFF
--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -128,7 +128,7 @@ ar:
     media: الصحافة والإعلام
     contact: التواصل
     funding: التمويل
-    donate_link: "https://actions.eko.org/a/ymknk-almsaadh-fy-tmkyn-sumofus-ltbqa-qwy-han"
+    donate_link: "https://actions.eko.org/a/ymknk-almsaadh-fy-tmkyn-eko-ltbqa-qwy-han"
     privacy_policy: الخصوصيّة
     controlshift: إطلاق حملتك الخاصّة
     twitter_link: https://twitter.com/Eko_Movement

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -127,7 +127,7 @@ es:
     media: Prensa
     contact: Contacto
     funding: Financiación
-    donate_link: https://actions.eko.org/a/tu-puedes-ayudar-a-que-sumofus-se-mantenga-con-fuerza
+    donate_link: https://actions.eko.org/a/tu-puedes-ayudar-a-que-eko-se-mantenga-con-fuerza
     privacy_policy: Política de Privacidad
     controlshift: Start your own campaign
     twitter_link: https://twitter.com/Eko_Movement

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -137,7 +137,7 @@ fr:
     introduction: "Ekō s’efforce à construire un monde où l’humain prévaut sur les profits des multinationales. Nous avons beaucoup de travail devant nous. Et nous vous proposons de devenir un donateur régulier afin de nous aidez à y arriver au plus vite. Un don mensuel aidera notre mouvement à planifier nos campagnes à l’avance afin de nous attaquer aux multinationales qui menacent notre planète et ses habitants. "
     chip_in: "Faites un don mensuel et rejoignez 17,462 membres-clé fantastiques dès aujourd’hui : "
     month: 'faire un don de %{amount}/mois'
-    donation_page_url: 'https://actions.eko.org/a/soutiner-sumofus-donate-french?source=homepage_151117_1_fr'
+    donation_page_url: 'https://actions.eko.org/a/soutiner-eko-donate-french?source=homepage_151117_1_fr'
   banner:
     content: "Grande nouvelle ! Vous avez récemment voté sur deux options de nom pour lancer un nouveau chapitre de l'aventure SumOfUs - et nous avons un gagnant !"
     read_more: "Lire la suite"


### PR DESCRIPTION
### Overview
Virginie reported that the French link to donate on the homepage needed to be fixed.
- I looked at it, and it is because the page links need to be updated with the new donate pages (after rebranding). The affected languages were French, Arabic and Spanish 